### PR TITLE
PH-2341: adds MS teams implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 [![Build](https://github.com/verifiedit/log-notifications/actions/workflows/build.yml/badge.svg)](https://github.com/verifiedit/log-notifications/actions/workflows/build.yml)
 
+## Support
+
+This package currently supports the following channels:
+- Mail
+- SMS (using verifiedit/laravel-notification-channel-clicksend)
+- Microsoft Teams (using laravel-notification-channels/microsoft-teams)
+
 ## Installation
 
 ```composer require verifiedit/log-notifications```
@@ -35,6 +42,7 @@ application: the name of which application is sending the notification.
 - defaults to your APP_NAME env variable with a fallback to 'Laravel', or this can be set in your ```log-notifications``` config by running ```php artisan vendor:publish --tag=log-notifications-config```. 
   
 message: the raw content sent to your recipient.
+- For Microsoft Teams, this assumes you are using laravel-notification-channels/microsoft-teams, the content of this notification is the payload stored as encoded json.
 - For email, this assumes you are using Laravel's MailMessage
 - For sms, this assumes you are using verifiedit/laravel-notification-channel-clicksend
   

--- a/src/Listeners/LogNotification/LogNotification.php
+++ b/src/Listeners/LogNotification/LogNotification.php
@@ -17,11 +17,16 @@ readonly class LogNotification
      */
     public function handle(NotificationSent $event): void
     {
-        $channel = $event->channel === 'NotificationChannels\\ClickSend\\ClickSendChannel' ? 'click-send' : $event->channel;
+        $channel = match ($event->channel) {
+            'mail' => 'mail',
+            'NotificationChannels\\ClickSend\\ClickSendChannel' => 'click-send',
+            'NotificationChannels\\MicrosoftTeams\\MicrosoftTeamsChannel' => 'microsoft-teams',
+            default => throw new Exception("{$event->channel} log notification processor not implemented"),
+        };
 
         $recipients = $this->formatRecipients($event->notifiable->routeNotificationFor($channel));
 
-        $data = (new LogNotificationProcessorSelector())->select($event->channel)->process($event, $recipients);
+        $data = (new LogNotificationProcessorSelector())->select($channel)->process($event, $recipients);
 
         $this->api->store($data);
     }

--- a/src/Listeners/LogNotification/LogNotificationProcessorSelector.php
+++ b/src/Listeners/LogNotification/LogNotificationProcessorSelector.php
@@ -14,7 +14,8 @@ class LogNotificationProcessorSelector
     {
         return match ($channel) {
             'mail' => new MailLogNotificationProcessor(),
-            'NotificationChannels\\ClickSend\\ClickSendChannel' => new ClickSendLogNotificationProcessor(),
+            'click-send' => new ClickSendLogNotificationProcessor(),
+            'microsoft-teams' => new MicrosoftTeamsLogNotificationProcessor(),
             default => throw new Exception("$channel log notification processor not implemented"),
         };
     }

--- a/src/Listeners/LogNotification/MicrosoftTeamsLogNotificationProcessor.php
+++ b/src/Listeners/LogNotification/MicrosoftTeamsLogNotificationProcessor.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Verifiedit\LogNotifications\Listeners\LogNotification;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Notifications\Events\NotificationSent;
+use Illuminate\Support\Facades\Config;
+use Verifiedit\LogNotifications\Contracts\LogNotificationProcessorContract;
+
+class MicrosoftTeamsLogNotificationProcessor implements LogNotificationProcessorContract
+{
+    public function process(NotificationSent $event, string $recipients): array
+    {
+        $data = [
+            'application' => Config::get('log-notifications.application-name'),
+            'channel' => 'microsoft-teams',
+            'reference' => $event->notification->id,
+            'serviceCommunications' => json_encode($event->response) ?: '',
+            'message' => '',
+            'recipient' => $recipients,
+            'sentAt' => CarbonImmutable::now(),
+            'subject' => null
+        ];
+
+        if (method_exists($event->notification, 'toMicrosoftTeams')) {
+            $data['message'] = json_encode($event->notification->toMicrosoftTeams($event->notifiable)->toArray());
+        }
+
+        return $data;
+    }
+}

--- a/tests/Unit/LogNotificationProcessorSelectorTest.php
+++ b/tests/Unit/LogNotificationProcessorSelectorTest.php
@@ -3,6 +3,7 @@
 use Verifiedit\LogNotifications\Listeners\LogNotification\ClickSendLogNotificationProcessor;
 use Verifiedit\LogNotifications\Listeners\LogNotification\LogNotificationProcessorSelector;
 use Verifiedit\LogNotifications\Listeners\LogNotification\MailLogNotificationProcessor;
+use Verifiedit\LogNotifications\Listeners\LogNotification\MicrosoftTeamsLogNotificationProcessor;
 
 it(
     'returns the correct processor',
@@ -18,7 +19,7 @@ it(
             ),
             'mail' => expect($processor)->toBeInstanceOf(MailLogNotificationProcessor::class),
             'microsoft-teams' => expect($processor)->toBeInstanceOf(
-                Verifiedit\LogNotifications\Listeners\LogNotification\MicrosoftTeamsLogNotificationProcessor::class),
+                MicrosoftTeamsLogNotificationProcessor::class),
             default => throw new Exception("$channel log notification processor not implemented"),
         };
     }

--- a/tests/Unit/LogNotificationProcessorSelectorTest.php
+++ b/tests/Unit/LogNotificationProcessorSelectorTest.php
@@ -13,14 +13,16 @@ it(
         $selector = new LogNotificationProcessorSelector();
         $processor = $selector->select($channel);
         match ($channel) {
-            'NotificationChannels\\ClickSend\\ClickSendChannel' => expect($processor)->toBeInstanceOf(
+            'click-send' => expect($processor)->toBeInstanceOf(
                 ClickSendLogNotificationProcessor::class
             ),
             'mail' => expect($processor)->toBeInstanceOf(MailLogNotificationProcessor::class),
+            'microsoft-teams' => expect($processor)->toBeInstanceOf(
+                Verifiedit\LogNotifications\Listeners\LogNotification\MicrosoftTeamsLogNotificationProcessor::class),
             default => throw new Exception("$channel log notification processor not implemented"),
         };
     }
-)->with(['NotificationChannels\\ClickSend\\ClickSendChannel', 'mail']);
+)->with(['click-send', 'mail', 'microsoft-teams']);
 
 it(
     'should throw exception if notification driver not implemented',


### PR DESCRIPTION
This pull request adds Microsoft Teams support to the log notification system and refactors channel handling for better consistency and extensibility. The main changes include introducing a dedicated processor for Microsoft Teams, updating channel identifiers to use consistent string values, and improving documentation to reflect the new features.

**Microsoft Teams channel support:**

* Added `MicrosoftTeamsLogNotificationProcessor` class to handle logging notifications sent via Microsoft Teams. This processor extracts and encodes the payload for storage. (`src/Listeners/LogNotification/MicrosoftTeamsLogNotificationProcessor.php`)
* Updated the channel handling logic in `LogNotification.php` to recognize and process the `microsoft-teams` channel, raising an exception for unsupported channels. (`src/Listeners/LogNotification/LogNotification.php`)
* Enhanced the processor selector to support the new `microsoft-teams` channel, returning the appropriate processor instance. (`src/Listeners/LogNotification/LogNotificationProcessorSelector.php`)

**Documentation updates:**

* Updated the `README.md` to list supported channels, including Microsoft Teams, and clarified the expected content format for each channel. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R45)

**Test coverage improvements:**

* Refactored unit tests to use the new channel string identifiers and added tests for the Microsoft Teams processor selection. (`tests/Unit/LogNotificationProcessorSelectorTest.php`)
