### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on:


### PR DESCRIPTION
Potential fix for [https://github.com/verifiedit/log-notifications/security/code-scanning/2](https://github.com/verifiedit/log-notifications/security/code-scanning/2)

In general, the fix is to explicitly declare `permissions:` for the `GITHUB_TOKEN` either at the workflow root (to apply to all jobs) or per job, and set them to the minimum required, typically `contents: read` for simple build/test workflows. This prevents inheriting broader default permissions from the repository/organization and documents the intended access.

For this specific workflow, both `tests` and `standards` jobs only check out the repository and run local actions. There is no evidence they need to write to the repo or manage issues/PRs, so setting `contents: read` at the workflow level is a safe, minimal change that will apply to both jobs without altering other behavior. The change should be inserted near the top of `.github/workflows/build.yml`, after the `on:` block (or before it; GitHub Actions accepts either), but within the shown snippet we can add it between the `on:` section and the `jobs:` key. No imports or additional files are needed; this is a pure YAML configuration change.

Concretely:
- Edit `.github/workflows/build.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

between line 8 (`pull_request:`) and line 9 (`jobs:`). This constrains `GITHUB_TOKEN` to repository contents read-only for all jobs in this workflow, satisfying the CodeQL recommendation while preserving existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
