### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/verifiedit/log-notifications/security/code-scanning/1](https://github.com/verifiedit/log-notifications/security/code-scanning/1)

In general, this should be fixed by explicitly setting a `permissions` block in the workflow, either at the top level (applying to all jobs) or on each job, restricting `GITHUB_TOKEN` to the minimal scopes required. For a build-and-test workflow that only needs to read repository contents, `permissions: contents: read` (optionally plus `packages: read` if package registry access is needed) is usually sufficient.

For this specific file, the least intrusive and clearest fix without changing existing behavior is to add a root-level `permissions` block right after the `name: Build` line. This block will apply to both `tests` and `standards` jobs since they do not define their own `permissions`. We’ll declare only `contents: read`, which is enough for `actions/checkout@v4` and for typical test/standards composite actions that read code but do not push changes. No imports or additional methods are needed because this is just a YAML configuration change within `.github/workflows/build.yml`.

Concretely:
- Edit `.github/workflows/build.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

- Place it between the existing `name: Build` and `on:` lines so that it applies globally.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
